### PR TITLE
Fixes webpack.config.js syntax error

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -26,6 +26,7 @@ module.exports = {
     'assets/css/app': [
       ...POLYFILLS,
       `${SRC}/css/app.js`
+    ]
   },
 
   output: {


### PR DESCRIPTION
It's missing a square bracket